### PR TITLE
Changed icon_size to 96

### DIFF
--- a/data/entities/teleporters/teleporters.lua
+++ b/data/entities/teleporters/teleporters.lua
@@ -86,7 +86,7 @@ teleporter_item.name = name
 teleporter_item.localised_name = localised_name
 teleporter_item.place_result = name
 teleporter_item.icon = path.."teleporter-icon.png"
-teleporter_item.icon_size = 97
+teleporter_item.icon_size = 96
 teleporter_item.subgroup = "circuit-network"
 
 


### PR DESCRIPTION
Fixes error while loading with

Failed to load mods: Error while loading item prototype "teleporter"(item):Sprite 'Teleporters/data/entities/teleporters/teleporter-icon.png' has mipmap count set to 4, so it's size is expected to be multiple of 8. But it's size is 97x97.